### PR TITLE
Fix bug which can cause TypeError: write() argument must be str, not …

### DIFF
--- a/civitAI_Model_downloader.py
+++ b/civitAI_Model_downloader.py
@@ -192,7 +192,7 @@ def download_model_files(item_name, model_version, item, download_type, failed_d
     item_dir = None
 
     # Extract the description and baseModel
-    description = item.get('description', '')
+    description = item.get('description') or ''
     base_model = item.get('baseModel')
     trigger_words =  model_version.get('trainedWords', [])
     


### PR DESCRIPTION
### **Merge Request: Fix `TypeError` when writing `None` model descriptions**

#### **Summary**
This MR fixes a `TypeError` occurring during the download process when a model's `description` field is `null`.

#### **Details**
- In some cases, the Civitai API returns `"description": null` in the model metadata.
- The script attempted to write this `None` value directly to a file, triggering:
  ```
  TypeError: write() argument must be str, not None
  ```
- The following line was updated:
  ```python
  description = item.get('description', '')
  ```
  **→**
  ```python
  description = item.get('description') or ''
  ```
  This ensures the `description` is always a valid string, even if the API returns `null`.

#### **Impact**
- Prevents runtime failure during large batch downloads.
- Improves robustness when handling inconsistent or incomplete API responses.

#### **Tested**
- Validated against users with known `null` descriptions.
- Confirmed that descriptions are correctly written or skipped without error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or empty descriptions to ensure consistent display and prevent errors when a description is not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->